### PR TITLE
skeleton prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+NAME = minishell
+CC = gcc
+CFLAGS = -Werror -Wall -Wextra 
+
+LDFLAGS = -lreadline -L${HOME}/.brew/opt/readline/lib
+CPPFLAGS = -I${HOME}/.brew/opt/readline/include
+
+INCLUDE_DIR	=	./include
+
+SRCS = main.c
+
+OBJS = $(SRCS:.c=.o)
+
+all : $(NAME)
+
+$(NAME) : $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o $(NAME)
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) -I$(INCLUDE_DIR) -c $< -o $@
+
+clean :
+	rm -rf $(OBJS)
+
+fclean : clean
+	rm -rf $(NAME)
+
+re : fclean all
+
+.PHONY : all clean fclean re

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -1,0 +1,6 @@
+#include <signal.h>
+#include <stdio.h>
+#include <readline/readline.h>
+#include <readline/history.h>
+#include <unistd.h>
+#include <stdlib.h>

--- a/main.c
+++ b/main.c
@@ -1,8 +1,37 @@
-int	main(int argc, char **argvm char **envp)
+#include "minishell.h"
+
+void handler(int signum)
 {
-	char	*input;
-	int		ret;
+	if (signum != SIGINT)
+		return;
+	printf("ctrl + c\n");
+	rl_on_new_line();
+	//rl_replace_line("", 1);
+	rl_redisplay();
+}
 
-	(void)argv;
+int main(void)
+{
+	int ret;
+	char *line;
 
+	ret = 1;
+	signal(SIGINT, handler);
+	while (1)
+	{
+		line = readline("input> ");
+		if (line)
+		{
+			if (ret)
+				printf("output> %s\n", line);
+			add_history(line);
+			free(line);
+			line = NULL;
+		}
+		else
+		{
+			printf("ctrl + d\n");
+		}
+	}
+	return (0);
 }

--- a/main.c
+++ b/main.c
@@ -1,0 +1,8 @@
+int	main(int argc, char **argvm char **envp)
+{
+	char	*input;
+	int		ret;
+
+	(void)argv;
+
+}


### PR DESCRIPTION
** I still couldn't figure out to run "rl_replace_line". **

1) As for Makefile, if you type this in cmd
"> brew info readline"
you can get this infomation.
"For compilers to find readline you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/readline/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/readline/include""
  
  So, you can directly compile like this. 
"gcc main.c -lreadline -L/Users/kay/.brew/opt/readline/lib -I/Users/kay/.brew/opt/readline/include -Iinclude"
  
I think you know everything else  ;)


2) As for main.c, I used `rl_on_new_line()` and `rl_redisplay` but failed to use `rl_replace_line`...
I spent so much time but couldn't figure out how to use...

I think we don't have to use my skeleton prompt but I did pull request just for saving your time ;)