### PR TITLE
fix test77, 78(127/146)

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -40,6 +40,7 @@ typedef struct s_node
 	int		quota_idx_j;
 	int		echo_skip;
 	char	**ori_args;
+	int		child_die;
 }	t_node;
 
 int		g_exit_status;
@@ -94,7 +95,7 @@ int		redir_excute(char **args, t_node *node);
 int		repeat_check(char **args, t_node *node);
 void	original_store(char **args, t_node *node);
 void	args_left_move(char **args, int i);
-int		print_err(char **args, int i);
+int		print_err(char **args, int i, t_node *node);
 // pipe
 void	exec_child(char **args, char **envp, t_node *node);
 void	exec_parents(int pid, char **args, char **envp, t_node *node);

--- a/pipe/utils_pipe.c
+++ b/pipe/utils_pipe.c
@@ -17,7 +17,8 @@ void	exec_child(char **args, char **envp, t_node *node)
 	close(node->fds[0]);
 	dup2(node->fds[1], STDOUT_FILENO);
 	close(node->fds[1]);
-	envp = find_command(args, envp, node);
+	if (node->child_die == 0)
+		envp = find_command(args, envp, node);
 	exit(g_exit_status);
 }
 
@@ -80,4 +81,5 @@ void	init_node(t_node *node)
 	node->pipe_idx = 0;
 	node->quota_pipe_cnt = 0;
 	node->echo_skip = 0;
+	node->child_die = 0;
 }

--- a/redirection/cmd_redir.c
+++ b/redirection/cmd_redir.c
@@ -17,7 +17,7 @@ int	left_redir(char **args, int i, t_node *node)
 	int	fd;
 
 	if (access(args[i + 1], R_OK))
-		return (print_err(args, i));
+		return (print_err(args, i, node));
 	fd = open(args[i + 1], O_RDONLY, 0744);
 	if (fd <= 0)
 		return (1);

--- a/redirection/utils_redir2.c
+++ b/redirection/utils_redir2.c
@@ -12,12 +12,19 @@
 
 #include "../include/minishell.h"
 
-int	print_err(char **args, int i)
+int	print_err(char **args, int i, t_node *node)
 {
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(args[i + 1], STDERR_FILENO);
 	ft_putstr_fd(": No such file or directory\n", STDERR_FILENO);
 	g_exit_status = 1;
+	if (pipe_check(args, node))
+	{
+		args_left_move(args, 1);
+		args_left_move(args, 0);
+		node->child_die = 1;
+		return (0);
+	}
 	return (1);
 }
 


### PR DESCRIPTION
Bro I found out that all the testcases we left is related to "./some directory/and newfile"
for example, Test  90: ❌ cat <"./test_files/infile" >"./outfiles/outfile01"
In this test 90, directory outfiles doesn't exist so I need to create directory first and source file.
As you can see, all the left testcases are related to this issues...
I checked ">>" this issue it works well.
I think this issue will take some days^^;;;;

So, what I wanted to say is that I finsihed all the pipe and redirection issues except this in minishell_tester.

I think we can say we almost done even it is enough to pass minishell I think,,!

However, I still left two things to fix for making this more stablization. 
1) "any message > any message"
It should not make 'any message' file.. However, our minishell makes the file.. I will figure out this
2) ls | exit 
It should not exit program just exit process bt our minishll finshed the program..

So, what I wanted to say is that I can finish this two concepts until 15th of Feb(The day you said that you want to finish our minishell). However I'm not sure I can finish the making directory issue in redirection. I think even we couldn't make our directory, we could easily pass minishell..! That's what I thought..!